### PR TITLE
Delete necklace.json

### DIFF
--- a/src/main/resources/data/trinkets/tags/items/chest/necklace.json
+++ b/src/main/resources/data/trinkets/tags/items/chest/necklace.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "bwplus:crown_of_the_forest"
-  ]
-}


### PR DESCRIPTION
Since the item no longer exists as the leshen is temporarily removed, removing this reference should fix mod compatibility with other mods that use the necklace trinket slot.