### PR TITLE
Avoid NullPointerExpection in LivingEntityMixin

### DIFF
--- a/src/main/java/dev/mrsterner/bewitchmentplus/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/dev/mrsterner/bewitchmentplus/mixin/common/LivingEntityMixin.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.ArmorItem;
+import net.minecraft.item.Item;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -74,7 +75,8 @@ public abstract class LivingEntityMixin extends Entity {
     @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
     private void deathRobes(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
         LivingEntity livingEntity = (LivingEntity)(Object)this;
-        if (livingEntity.getEquippedStack(EquipmentSlot.CHEST).getItem().equals(BWPObjects.DEATHS_ROBES) && source.isFire()) {
+        Item is = livingEntity.getEquippedStack(EquipmentSlot.CHEST).getItem();
+        if (is != null && is.equals(BWPObjects.DEATHS_ROBES) && source.isFire()) {
             cir.setReturnValue(false);
         }
     }
@@ -89,8 +91,12 @@ public abstract class LivingEntityMixin extends Entity {
     @Inject(method = "tickMovement", at = @At("HEAD"))
     private void deathWalk(CallbackInfo ci){
         LivingEntity livingEntity = (LivingEntity)(Object)this;
-        this.walkOnFluid = livingEntity.getEquippedStack(EquipmentSlot.FEET).getItem().equals(BWPObjects.DEATHS_FOOTWEAR);
-
+        Item is = livingEntity.getEquippedStack(EquipmentSlot.FEET).getItem();
+        if (is == null) {
+            this.walkOnFluid = false;
+        } else {
+            this.walkOnFluid = is.equals(BWPObjects.DEATHS_FOOTWEAR);
+        }
     }
     @Inject(method = "tickMovement", at = @At("HEAD"))
     private void deathParticle(CallbackInfo ci){

--- a/src/main/java/dev/mrsterner/bewitchmentplus/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/dev/mrsterner/bewitchmentplus/mixin/common/LivingEntityMixin.java
@@ -92,12 +92,9 @@ public abstract class LivingEntityMixin extends Entity {
     private void deathWalk(CallbackInfo ci){
         LivingEntity livingEntity = (LivingEntity)(Object)this;
         Item is = livingEntity.getEquippedStack(EquipmentSlot.FEET).getItem();
-        if (is == null) {
-            this.walkOnFluid = false;
-        } else {
-            this.walkOnFluid = is.equals(BWPObjects.DEATHS_FOOTWEAR);
-        }
+        this.walkOnFluid = is != null && is.equals(BWPObjects.DEATHS_FOOTWEAR);
     }
+    
     @Inject(method = "tickMovement", at = @At("HEAD"))
     private void deathParticle(CallbackInfo ci){
         LivingEntity livingEntity = (LivingEntity)(Object)this;


### PR DESCRIPTION
Under some circumstances, `getEquippedStack(...).getItem()` can return null. This can cause seemingly random crashes such as the one in [this crash report](https://github.com/BloomhouseMC/Bewitchment-Plus/files/10672953/crash-2023-02-04_16.01.14-client.txt).

This patch ensures that the return value is not null before calling `Item.equals()`.
